### PR TITLE
fixed EarlyStopping

### DIFF
--- a/seqmod/misc/early_stopping.py
+++ b/seqmod/misc/early_stopping.py
@@ -83,7 +83,7 @@ class EarlyStopping(pqueue):
 
     def __init__(self, maxsize, patience=None, reset_patience=True):
         """Set params."""
-        self.patience, self.fails = patience or maxsize, 0
+        self.patience, self.fails = patience or maxsize - 1, 0
         self.reset_patience = reset_patience
         self.stopped = False
 


### PR DESCRIPTION
Biggest change is in this line https://github.com/emanjavacas/seqmod/blob/master/seqmod/misc/early_stopping.py#L85. Order has been switched to actually reflect "patience must be smaller than maxsize". Rest is more clean numpy-style documentation.