### PR TITLE
fixed ES tolerance

### DIFF
--- a/seqmod/misc/early_stopping.py
+++ b/seqmod/misc/early_stopping.py
@@ -100,20 +100,21 @@ class EarlyStopping(pqueue):
 
     def add_checkpoint(self, checkpoint, model=None):
         """Add loss to queue and stop if patience is exceeded."""
+        if not self.is_empty():
+            smallest, model = self.get_min()
+            if (checkpoint + self.tolerance) > smallest:
+                self.fails += 1
+                if self.fails == self.patience:
+                    self.stopped = True
+                    msg = "Stop after {} checkpoints. ".format(self.patience)
+                    msg += "Best score {:.3f} ".format(smallest)
+                    msg += "at checkpoint {}.".format(self.find_smallest())
+                    raise EarlyStoppingException(
+                        msg, {'model': model,
+                              'smallest': smallest})
+
         self.push(model, checkpoint)
         self.checks.append(checkpoint)
-        smallest, model = self.get_min()
-
-        if checkpoint + self.tolerance > smallest:
-            self.fails += 1
-            if self.fails == self.patience:
-                self.stopped = True
-                msg = "Stop after {} checkpoints. ".format(self.patience)
-                msg += "Best score {:.3f} ".format(smallest)
-                msg += "at checkpoint {}.".format(self.find_smallest())
-                raise EarlyStoppingException(
-                    msg, {'model': model,
-                          'smallest': smallest})
 
         if self.is_full():
             checkpoint, model = self.get_min()


### PR DESCRIPTION
Push checkpoint results to stack only after checking for early stopping sign. 

**Note**: this might also make the -1 offset to `maxsize` unnecessary.